### PR TITLE
GET /api/articles/:article_id (comment count)

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -43,7 +43,7 @@ describe("GET /api/topics", () => {
 });
 
 describe("GET /api/articles/:article_id", () => {
-  test("returns status 200", () => {
+  test("returns status 200 with returned object", () => {
     return request(app)
       .get("/api/articles/1")
       .expect(200)
@@ -56,6 +56,7 @@ describe("GET /api/articles/:article_id", () => {
           title: "Living in the shadow of a great man",
           topic: "mitch",
           votes: 100,
+          comment_count: 11,
         });
       });
   });
@@ -75,6 +76,15 @@ describe("GET /api/articles/:article_id", () => {
       .expect(400)
       .then(({ body }) => {
         expect(body.msg).toBe("bad request");
+      });
+  });
+
+  test("should return an object that includes the comment_count property", () => {
+    return request(app)
+      .get("/api/articles/1")
+      .expect(200)
+      .then(({ body }) => {
+        expect(body.article).toHaveProperty("comment_count");
       });
   });
 });
@@ -152,27 +162,27 @@ describe("PATCH /api/articles/:article_id", () => {
         expect(body.msg).toBe("No article found for article_id: 199");
       });
   });
+});
 
-  describe("GET /api/users", () => {
-    test("should return status 200", () => {
-      return request(app).get("/api/users").expect(200);
-    });
+describe("GET /api/users", () => {
+  test("should return status 200", () => {
+    return request(app).get("/api/users").expect(200);
+  });
 
-    test("should return an array of objects", () => {
-      return request(app)
-        .get("/api/users")
-        .then(({ body }) => {
-          const { users } = body;
-          expect(users).toBeInstanceOf(Array);
-          expect(users).toHaveLength(4);
-          users.forEach((user) => {
-            expect(user).toEqual(
-              expect.objectContaining({
-                username: expect.any(String),
-              })
-            );
-          });
+  test("should return an array of objects", () => {
+    return request(app)
+      .get("/api/users")
+      .then(({ body }) => {
+        const { users } = body;
+        expect(users).toBeInstanceOf(Array);
+        expect(users).toHaveLength(4);
+        users.forEach((user) => {
+          expect(user).toEqual(
+            expect.objectContaining({
+              username: expect.any(String),
+            })
+          );
         });
-    });
+      });
   });
 });

--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -78,15 +78,6 @@ describe("GET /api/articles/:article_id", () => {
         expect(body.msg).toBe("bad request");
       });
   });
-
-  test("should return an object that includes the comment_count property", () => {
-    return request(app)
-      .get("/api/articles/1")
-      .expect(200)
-      .then(({ body }) => {
-        expect(body.article).toHaveProperty("comment_count");
-      });
-  });
 });
 
 describe("PATCH /api/articles/:article_id", () => {
@@ -165,13 +156,10 @@ describe("PATCH /api/articles/:article_id", () => {
 });
 
 describe("GET /api/users", () => {
-  test("should return status 200", () => {
-    return request(app).get("/api/users").expect(200);
-  });
-
-  test("should return an array of objects", () => {
+  test("should return 200 and an array of objects", () => {
     return request(app)
       .get("/api/users")
+      .expect(200)
       .then(({ body }) => {
         const { users } = body;
         expect(users).toBeInstanceOf(Array);

--- a/models/news.js
+++ b/models/news.js
@@ -6,8 +6,9 @@ exports.selectTopics = () => {
 
 exports.selectArticleById = (article_id) => {
   return db
+
     .query(
-      "select users.username AS author, title, article_id, body, topic, created_at, votes from articles INNER JOIN users ON articles.author = users.username where article_id = $1;",
+      "select users.username AS author, title, articles.article_id, articles.body, topic, articles.created_at, articles.votes, count(comment_id)::INT AS comment_count FROM articles INNER JOIN users ON articles.author = users.username LEFT JOIN comments ON articles.article_id = comments.article_id where comments.article_id = $1 GROUP BY articles.article_id, users.username ;",
       [article_id]
     )
     .then((result) => {


### PR DESCRIPTION
FEATURE REQUEST
An article response object should also now include:

-comment_count which is the total count of all the comments with this article_id - you should make use of queries to the database in order to achieve this.

